### PR TITLE
added Below the Arks check for Empty Memories

### DIFF
--- a/scripts/quests/jeuno/Empty_Memories.lua
+++ b/scripts/quests/jeuno/Empty_Memories.lua
@@ -48,7 +48,8 @@ quest.sections =
         check = function(player, status, vars)
             return status == xi.questStatus.QUEST_AVAILABLE and
             (player:getCurrentMission(xi.mission.log_id.COP) > xi.mission.id.cop.THE_MOTHERCRYSTALS or
-            xi.mission.getVar(player, xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS, 'Option') > 0)
+            xi.mission.getVar(player, xi.mission.log_id.COP, xi.mission.id.cop.THE_MOTHERCRYSTALS) or
+            xi.mission.getVar(player, xi.mission.log_id.COP, xi.mission.id.cop.BELOW_THE_ARKS, 'Option') > 0)
         end,
 
         [xi.zone.RULUDE_GARDENS] =


### PR DESCRIPTION
## What does this pull request do?
Allows "Empty Memories" quest to be activated with mission "Below the Arks" as current mission.

## Steps to test these changes
Talk to Harith NPC in RuLude Gardens. 