### PR TITLE
Add Orichalcum Ingot as Custom Drop

### DIFF
--- a/TRACKER.md
+++ b/TRACKER.md
@@ -11,8 +11,6 @@
     - Quest: *Enter Quest Name Here*
     - Description: 
 
----
-
 ## Custom NPCs
 - [ ] Completed:
     - NPC: *Enter NPC Name Here*
@@ -23,8 +21,6 @@
 - [ ] Completed:
     - NPC: *Enter NPC Name Here*
     - Description: 
-
----
 
 ## Custom Mob Drops
 - [ ] Completed:
@@ -37,8 +33,6 @@
     - Mob Drop: *Enter Mob or Drop Detail Here*
     - Description: 
 
----
-
 ## Bug Fixes
 - [ ] Completed:
     - Bug: *Enter Bug Description or Type Here*
@@ -49,7 +43,3 @@
 - [ ] Completed:
     - Bug: *Enter Bug Description or Type Here*
     - Description: 
-
----
-
-

--- a/TRACKER.md
+++ b/TRACKER.md
@@ -1,0 +1,55 @@
+# Task Tracker
+
+## Custom Quests
+- [x] Completed: 2025-03-05
+    - Quest: Shell We Hop Right In?
+    - Description: Add NPC(s) that rewards the player with a Beastly Shank (3341) when traded a Crab Apron (539) and a Wild Rabbit Tail (542).
+- [ ] Completed: 
+    - Quest: *Enter Quest Name Here*
+    - Description: 
+- [ ] Completed:
+    - Quest: *Enter Quest Name Here*
+    - Description: 
+
+---
+
+## Custom NPCs
+- [ ] Completed:
+    - NPC: *Enter NPC Name Here*
+    - Description: 
+- [ ] Completed:
+    - NPC: *Enter NPC Name Here*
+    - Description: 
+- [ ] Completed:
+    - NPC: *Enter NPC Name Here*
+    - Description: 
+
+---
+
+## Custom Mob Drops
+- [ ] Completed:
+    - Mob Drop: *Enter Mob or Drop Detail Here*
+    - Description: 
+- [ ] Completed:
+    - Mob Drop: *Enter Mob or Drop Detail Here*
+    - Description: 
+- [ ] Completed:
+    - Mob Drop: *Enter Mob or Drop Detail Here*
+    - Description: 
+
+---
+
+## Bug Fixes
+- [ ] Completed:
+    - Bug: *Enter Bug Description or Type Here*
+    - Description: 
+- [ ] Completed:
+    - Bug: *Enter Bug Description or Type Here*
+    - Description: 
+- [ ] Completed:
+    - Bug: *Enter Bug Description or Type Here*
+    - Description: 
+
+---
+
+

--- a/modules/morecustom/sql/mobs/custom_mob_drops.sql
+++ b/modules/morecustom/sql/mobs/custom_mob_drops.sql
@@ -1,0 +1,7 @@
+-- custom mob drops
+
+-- ZoneID: 127 - Behemoth
+INSERT INTO `mob_droplist` VALUES (251,0,0,1000,747,@ALWAYS); -- Orichalcum Ingot (Always, 100%)
+
+-- ZoneID: 127 - King Behemoth
+INSERT INTO `mob_droplist` VALUES (1450,0,0,1000,747,@ALWAYS) -- Orichalcum Ingot (Always, 100%)


### PR DESCRIPTION
## What does this pull request do?

Add Orichalcum Ingot as a drop from Behemoth and King Behemoth with 100% drop rate.

## Steps to test these changes
**_Behemoth_**
!spawnmob 17093000
Kill and see Orichalcum Ingot drop.

**_King Behemoth_**
!spawnmob 17297441
Kill and see Orichalcum Ingot drop.
